### PR TITLE
Add `injection` iceberg usecase

### DIFF
--- a/iceberg/datasets/gdelt/fetch.sh
+++ b/iceberg/datasets/gdelt/fetch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DATE="$1"
+
+OLD="`date +%Y%m%d`"
+
+if [ -z $DATE ]; then
+  DATE="`date +%Y%m%d`"
+fi
+
+echo "Downloading from http://data.gdeltproject.org/events/$DATE.export.CSV.zip"
+curl -O http://data.gdeltproject.org/events/$DATE.export.CSV.zip
+
+echo "Extracting $DATE.export.CSV.zip"
+unzip $DATE.export.CSV.zip

--- a/iceberg/usecases/injection/pom.xml
+++ b/iceberg/usecases/injection/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dremio.iceland.iceberg</groupId>
+    <artifactId>injection</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.15.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-spark-3.5_2.13</artifactId>
+            <version>1.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-spark-extensions-3.5_2.13</artifactId>
+            <version>1.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.13</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.13</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/Analytics.java
+++ b/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/Analytics.java
@@ -1,0 +1,24 @@
+package com.dremio.iceland.iceberg.injection;
+
+import org.apache.spark.sql.SparkSession;
+
+public class Analytics {
+
+    public static void main(String... args) throws Exception {
+        try (SparkSession spark = SparkProvider.get()) {
+            System.out.println("Number of Events");
+            spark.sql("SELECT COUNT(*) FROM iceland.gdelt.events").show();
+
+            System.out.println("Top 10: Events ordered by number of articles");
+            spark.sql("SELECT * FROM iceland.gdelt.events ORDER by NumArticles DESC LIMIT 10").show();
+            System.out.println("Top 10: Events ordered by number of mentions");
+            spark.sql("SELECT * FROM iceland.gdelt.events ORDER by NumMentions DESC LIMIT 10").show();
+            System.out.println("Top 10: Events ordered by average tone");
+            spark.sql("SELECT * FROM iceland.gdelt.events ORDER by AvgTone DESC LIMIT 10").show();
+
+            System.out.println("Number of events in the US");
+            spark.sql("SELECT count(*) FROM iceland.gdelt.events WHERE Country = \"US\"").show();
+        }
+    }
+
+}

--- a/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/CreateTable.java
+++ b/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/CreateTable.java
@@ -1,0 +1,29 @@
+package com.dremio.iceland.iceberg.injection;
+
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Create the GDELT iceberg table, ready to receive events/news.
+ */
+public class CreateTable {
+
+    public static final void main(String... args) throws Exception {
+        try (SparkSession spark = SparkProvider.get()) {
+            spark.sql("CREATE TABLE iceland.gdelt.events(" +
+                    "EventID bigint," +
+                    "Date int," +
+                    "NumMentions int," +
+                    "NumSources int," +
+                    "NumArticles int," +
+                    "AvgTone double," +
+                    "Location string," +
+                    "Country string," +
+                    "Latitude double," +
+                    "Longitude double," +
+                    "Source string" +
+                    ") USING iceberg " +
+                    "PARTITIONED BY (Date)");
+        }
+    }
+
+}

--- a/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/DataInjection.java
+++ b/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/DataInjection.java
@@ -1,0 +1,89 @@
+package com.dremio.iceland.iceberg.injection;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.spark.sql.SparkSession;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class DataInjection {
+
+    public static void main(String... args) throws Exception {
+
+        String location = "gdelt.csv";
+
+        if (args.length == 2) {
+            location = args[1];
+        }
+
+        Path file = Paths.get(location);
+        if (!Files.exists(file)) {
+            System.err.println(file.toAbsolutePath() + " doesn't exist");
+            System.exit(1);
+        }
+
+        try (SparkSession spark = SparkProvider.get()) {
+            List<List<String>> lines = parse(file.toFile());
+
+            for (List<String> line : lines) {
+                StringBuilder builder = new StringBuilder();
+                builder.append("INSERT INTO iceland.gdelt.events VALUES(");
+
+                // GLOBALEVENTID
+                builder.append(line.get(0)).append(",");
+                // SQLDATE
+                builder.append(line.get(1)).append(",");
+
+                // NumMentions
+                builder.append(line.get(31)).append(",");
+                // NumSources
+                builder.append(line.get(32)).append(",");
+                // NumArticles
+                builder.append(line.get(33)).append(",");
+                // AvgTone
+                builder.append(line.get(34)).append(",");
+
+                // ActionGeo_FullName
+                builder.append("\"").append(line.get(50)).append("\"").append(",");
+                // ActionGeo_CountryCode
+                builder.append("\"").append(line.get(51)).append("\"").append(",");
+
+                // ActionGeo_Lat
+                builder.append(line.get(53).isEmpty() ? "null" : line.get(53)).append(",");
+                // ActionGeo_Long
+                builder.append(line.get(54).isEmpty() ? "null" : line.get(54)).append(",");
+
+                // SOURCEURL
+                builder.append("\"").append(line.get(57)).append("\"");
+
+                builder.append(")");
+
+                System.out.println(builder);
+
+                spark.sql(builder.toString());
+            }
+
+        }
+    }
+
+    private static List<List<String>> parse(File file) throws IOException {
+        List<List<String>> result = new ArrayList<>();
+        try (CSVParser parser = CSVParser.parse(file, StandardCharsets.UTF_8, CSVFormat.TDF)) {
+            for (CSVRecord record : parser) {
+                result.add(record.toList());
+            }
+        }
+        return result;
+    }
+
+
+}

--- a/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/SparkProvider.java
+++ b/iceberg/usecases/injection/src/main/java/com/dremio/iceland/iceberg/injection/SparkProvider.java
@@ -1,0 +1,24 @@
+package com.dremio.iceland.iceberg.injection;
+
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
+import org.apache.spark.sql.SparkSession;
+
+public class SparkProvider {
+
+    public static SparkSession get() {
+        return SparkSession.builder()
+                .master("local[2]")
+                .appName("simple")
+                .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+                .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+                .config("spark.sql.catalog.spark_catalog.type", "hive")
+                .config("spark.sql.catalog.local", SparkCatalog.class.getName())
+                .config("spark.sql.catalog.local.type", "hadoop")
+                .config("spark.sql.catalog.local.warehouse", ".")
+                .config("spark.sql.defaultCatalog", "local")
+                .getOrCreate();
+    }
+
+}


### PR DESCRIPTION
This first PR create the skeleton and add a first `injection` use case.

This `injection` use case:
1. provides a script to fetch GDELT data as CSV file, ready to be parsed and inserted in the Iceberg table
2. `CreateTable` creates a Iceberg table to store GDELT events
3. `DataInjection` parses the GDELT CSV file and insert data in the Iceberg table
4. `Analytics` provides the first simple queries

NB: when merged, I will create a blog post based on this PR.